### PR TITLE
docs: update deprecated flag

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -14,7 +14,7 @@ including macOS, Windows, and Linux. To get started:
 - install TextRunner:
 
   <pre type="npm/install" dir="../text-runner-cli">
-  npm install --dev text-runner
+  npm install --include=dev text-runner
   </pre>
 
 - make sure it works by running:


### PR DESCRIPTION
When running
`npm install --dev text-runner`

I get this warning
`npm WARN install Usage of the `--dev` option is deprecated. Use `--include=dev` instead.`

This patch changes the command in documentation accordingly.