### PR TITLE
Fix linter warning messages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ import sortKeys from "eslint-plugin-typescript-sort-keys"
 export default [
   {
     files: ["**/*.ts"],
-    ignores: ["**/node_modules/", ".git/", "**/dist/**"],
+    ignores: ["**/node_modules/", ".git/", "dist/", "**/dist/**"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",

--- a/shared/cucumber-steps/package.json
+++ b/shared/cucumber-steps/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig-build.json",
     "clean": "rm -rf dist",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "devDependencies": {

--- a/shared/cucumber-steps/package.json
+++ b/shared/cucumber-steps/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig-build.json",
     "clean": "rm -rf dist",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --config=../../eslint.config.mjs --ignore-pattern=dist . && depcheck --config=../../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "devDependencies": {

--- a/shared/cucumber-steps/package.json
+++ b/shared/cucumber-steps/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig-build.json",
     "clean": "rm -rf dist",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../../.depcheckrc",
+    "lint": "prettier -l . && eslint --config=../../eslint.config.mjs --ignore-pattern=dist . && depcheck --config=../../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "devDependencies": {

--- a/text-runner-cli/package.json
+++ b/text-runner-cli/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run --format=summary",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
     "stats": "find . -type f | grep -v /node_modules/ | grep -v /dist/ | grep -v \\./.git/ | grep -v \\.\\/\\.vscode/ | grep -v \\.\\/tmp\\/ | xargs scc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },

--- a/text-runner-cli/package.json
+++ b/text-runner-cli/package.json
@@ -24,7 +24,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run --format=summary",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../.depcheckrc",
     "stats": "find . -type f | grep -v /node_modules/ | grep -v /dist/ | grep -v \\./.git/ | grep -v \\.\\/\\.vscode/ | grep -v \\.\\/tmp\\/ | xargs scc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },

--- a/text-runner-core/package.json
+++ b/text-runner-core/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run --format=summary",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "eslint --ignore-pattern=dist . && prettier -l . && depcheck",
+    "lint": "eslint --ignore-pattern=dist/ . && prettier -l . && depcheck",
     "stats": "find . -type f | grep -v /node_modules/ | grep -v /dist/ | grep -v \\./\\.git/ | grep -v \\./\\.vscode/ | grep -v \\./tmp/ | xargs scc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },

--- a/text-runner-core/package.json
+++ b/text-runner-core/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run --format=summary",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "eslint . && prettier -l . && depcheck",
+    "lint": "eslint --config=../eslint.config.mjs --ignore-pattern=dist . && prettier -l . && depcheck",
     "stats": "find . -type f | grep -v /node_modules/ | grep -v /dist/ | grep -v \\./\\.git/ | grep -v \\./\\.vscode/ | grep -v \\./tmp/ | xargs scc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },

--- a/text-runner-core/package.json
+++ b/text-runner-core/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run --format=summary",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "eslint --config=../eslint.config.mjs --ignore-pattern=dist . && prettier -l . && depcheck",
+    "lint": "eslint --ignore-pattern=dist . && prettier -l . && depcheck",
     "stats": "find . -type f | grep -v /node_modules/ | grep -v /dist/ | grep -v \\./\\.git/ | grep -v \\./\\.vscode/ | grep -v \\./tmp/ | xargs scc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },

--- a/textrun-action/package.json
+++ b/textrun-action/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc"
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../.depcheckrc"
   },
   "dependencies": {
     "text-runner-core": "6.0.0"

--- a/textrun-action/package.json
+++ b/textrun-action/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../.depcheckrc"
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc"
   },
   "dependencies": {
     "text-runner-core": "6.0.0"

--- a/textrun-extension/package.json
+++ b/textrun-extension/package.json
@@ -15,7 +15,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-extension/package.json
+++ b/textrun-extension/package.json
@@ -15,7 +15,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-javascript/package.json
+++ b/textrun-javascript/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-javascript/package.json
+++ b/textrun-javascript/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-make/package.json
+++ b/textrun-make/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-make/package.json
+++ b/textrun-make/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-npm/package.json
+++ b/textrun-npm/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-npm/package.json
+++ b/textrun-npm/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-repo/package.json
+++ b/textrun-repo/package.json
@@ -14,7 +14,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../.depcheckrc"
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc"
   },
   "dependencies": {
     "assert-no-diff": "3.0.6",

--- a/textrun-repo/package.json
+++ b/textrun-repo/package.json
@@ -14,7 +14,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc"
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../.depcheckrc"
   },
   "dependencies": {
     "assert-no-diff": "3.0.6",

--- a/textrun-shell/package.json
+++ b/textrun-shell/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck --config=../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-shell/package.json
+++ b/textrun-shell/package.json
@@ -13,7 +13,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck --config=../.depcheckrc",
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck --config=../.depcheckrc",
     "unit": "env NODE_NO_WARNINGS=1 mocha --reporter=dot 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/textrun-workspace/package.json
+++ b/textrun-workspace/package.json
@@ -14,7 +14,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --online --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint . && depcheck"
+    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck"
   },
   "dependencies": {
     "assert-no-diff": "3.0.6",

--- a/textrun-workspace/package.json
+++ b/textrun-workspace/package.json
@@ -14,7 +14,7 @@
     "cuke": "cucumber-js --format=progress",
     "doc": "text-run static --online --format=summary && text-run dynamic --format=progress",
     "fix": "eslint . --fix && prettier --write .",
-    "lint": "prettier -l . && eslint --ignore-pattern=dist . && depcheck"
+    "lint": "prettier -l . && eslint --ignore-pattern=dist/ . && depcheck"
   },
   "dependencies": {
     "assert-no-diff": "3.0.6",


### PR DESCRIPTION
And make linters run faster by not double-checking the compiled JS output.

Somehow eslint does not use the `ignore` directive in the config file.