### PR TITLE
remove tsx, use experimental-strip-types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:  # remove all build artifacts
 	find . -name node_modules -type d | xargs rm -rf
 
 cuke:  # runs all E2E tests
-	env $(YARN_ARGS) yarn exec --silent -- turbo run cuke --concurrency=1
+	env $(YARN_ARGS) yarn exec --silent -- turbo run cuke $(TURBO_ARGS)
 
 doc:  # runs the documentation tests
 	env $(YARN_ARGS) yarn exec --silent -- turbo run doc $(TURBO_ARGS)

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -3,7 +3,7 @@
 TextRunner works on all platforms supported by [Node.JS](https://nodejs.org),
 including macOS, Windows, and Linux. To get started:
 
-- install [Node.JS](https://nodejs.org) version 16 or newer
+- install [Node.JS](https://nodejs.org) version 22 or newer
 - in the terminal, cd into the folder in which you want to use TextRunner
 - make sure you have a file <a type="workspace/new-file"> **package.json** with
   at least these entries:

--- a/documentation/user-defined-actions.md
+++ b/documentation/user-defined-actions.md
@@ -46,8 +46,8 @@ hello.md:1 -- Hello world
 
 ## How it works
 
-An action is a simple JavaScript function. It receives an object containing
-information and utility functions:
+An action is a simple JavaScript or TypeScript function. It receives an object
+containing information and utility functions:
 
 <a type="all-action-args" ignore="linkTargets">
 
@@ -76,7 +76,8 @@ Examples for custom actions written in ESM are
 [here](../examples/custom-action-esm/text-runner/hello-world.js). You can write
 functions in [TypeScript](../examples/custom-action-typescript/) or in classic
 [CommonJS](../examples/custom-action-commonjs/text-runner/hello-world.js). Throw
-an exception to fail a test.
+an exception to fail a test. Use only [strippable
+types](https://nodejs.org/en/learn/typescript/run-natively).
 
 ## Accessing document content
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,5 +1,5 @@
 This folder contains workspaces for end-to-end tests. The current ESM
-implementation requires `text-runner`, `tsx`, and `typescript` installed into a
+implementation requires `text-runner` and `typescript` installed into a
 `node_modules` folder. Since it takes too much time to `yarn install` this for
 every end-to-end test, the workspaces in which tests happen are now part of the
 Yarn multi-workspace setup in this monorepo.

--- a/test/features_12/package.json
+++ b/test/features_12/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_13/package.json
+++ b/test/features_13/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_14/package.json
+++ b/test/features_14/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_15/package.json
+++ b/test/features_15/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_2/package.json
+++ b/test/features_2/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_3/package.json
+++ b/test/features_3/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_4/package.json
+++ b/test/features_4/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_5/package.json
+++ b/test/features_5/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_6/package.json
+++ b/test/features_6/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_7/package.json
+++ b/test/features_7/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_8/package.json
+++ b/test/features_8/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/features_9/package.json
+++ b/test/features_9/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/javascript/package.json
+++ b/test/javascript/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/make/package.json
+++ b/test/make/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/npm/package.json
+++ b/test/npm/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/repo/package.json
+++ b/test/repo/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/shell/package.json
+++ b/test/shell/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/test/workspace/package.json
+++ b/test/workspace/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "devDependencies": {
     "text-runner": "7.0.0",
-    "tsx": "4.19.3",
     "typescript": "5.7.3"
   }
 }

--- a/text-runner-cli/bin/text-runner
+++ b/text-runner-cli/bin/text-runner
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env node --experimental-strip-types
 
 import { start } from "../dist/start.js"
 start()

--- a/text-runner-cli/bin/text-runner
+++ b/text-runner-cli/bin/text-runner
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types
+#!/usr/bin/env -S node --experimental-strip-types
 
 import { start } from "../dist/start.js"
 start()

--- a/text-runner-cli/package.json
+++ b/text-runner-cli/package.json
@@ -33,8 +33,7 @@
     "end-child-processes": "1.0.3",
     "jsonc-reader": "0.1.2",
     "minimist": "1.2.8",
-    "text-runner-core": "7.0.0",
-    "tsx": "4.19.3"
+    "text-runner-core": "7.0.0"
   },
   "devDependencies": {
     "@types/babel__code-frame": "7.0.6",

--- a/text-runner-features/package.json
+++ b/text-runner-features/package.json
@@ -5,9 +5,9 @@
   "license": "ISC",
   "type": "module",
   "scripts": {
-    "cuke": "cucumber-js --tags='(not @online) and (not @todo) and (not @cli)' --format=progress --parallel=`node -e 'console.log(os.cpus().length)'` '**/*.feature' && npm run cuke:cli",
+    "cuke": "cucumber-js --tags='(not @online) and (not @todo)' --format=progress --parallel=`node -e 'console.log(os.cpus().length)'` '**/*.feature'",
     "cuke:api": "cucumber-js --tags='(not @online) and (not @todo) and (@api)' --format=progress --parallel=`node -e 'console.log(os.cpus().length)'` '**/*.feature'",
-    "cuke:cli": "cucumber-js --tags='(not @online) and (not @todo) and (@cli)' --format=progress '**/*.feature'",
+    "cuke:cli": "cucumber-js --tags='(not @online) and (not @todo) and (@cli)' --format=progress --parallel=`node -e 'console.log(os.cpus().length)'` '**/*.feature'",
     "cuke:online": "cucumber-js --tags='(not @todo) and @online' --format=progress --parallel=`node -e 'console.log(os.cpus().length)`",
     "cuke:smoke": "cucumber-js --tags=@smoke --format=progress '**/*.feature'"
   },

--- a/textrun-action/package.json
+++ b/textrun-action/package.json
@@ -18,7 +18,6 @@
     "text-runner-core": "7.0.0"
   },
   "devDependencies": {
-    "text-runner": "7.0.0",
-    "tsx": "4.19.3"
+    "text-runner": "7.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,7 +56,6 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
-    "allowImportingTsExtensions": true,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -30,11 +31,13 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": false /* Raise error on 'this' expressions with an implied 'any' type. */,
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
     /* Additional Checks */
     "noUnusedLocals": true /* Report errors on unused locals. */,
     "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+
     /* Module Resolution Options */
     // "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -46,14 +49,17 @@
     // "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -31,13 +30,11 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": false /* Raise error on 'this' expressions with an implied 'any' type. */,
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
     /* Additional Checks */
     "noUnusedLocals": true /* Report errors on unused locals. */,
     "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
     /* Module Resolution Options */
     // "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -49,19 +46,17 @@
     // "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "allowImportingTsExtensions": true,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
TSX works great, but using it introduces a race condition in npm, requiring us to run the end-to-end tests sequentially. It's also not really needed in production code. Custom actions are typically small TypeScript files that can easily be stripped. More complex custom actions in npm modules will still be transpiled.